### PR TITLE
onError exception handling

### DIFF
--- a/src/Loading/Plugins/babylon.babylonFileLoader.ts
+++ b/src/Loading/Plugins/babylon.babylonFileLoader.ts
@@ -38,7 +38,7 @@
 
             return false;
         },
-        importMesh: (meshesNames: any, scene: Scene, data: any, rootUrl: string, meshes: AbstractMesh[], particleSystems: ParticleSystem[], skeletons: Skeleton[]): boolean => {
+        importMesh: (meshesNames: any, scene: Scene, data: any, rootUrl: string, meshes: AbstractMesh[], particleSystems: ParticleSystem[], skeletons: Skeleton[], onError?: (message: string, exception?: any) => void): boolean => {
             // Entire method running in try block, so ALWAYS logs as far as it got, only actually writes details
             // when SceneLoader.debugLogging = true (default), or exception encountered.
             // Everything stored in var log instead of writing separate lines to support only writing in exception,
@@ -53,7 +53,7 @@
                 } else if (!Array.isArray(meshesNames)) {
                     meshesNames = [meshesNames];
                 }
-                
+
                 if (parsedData.meshes !== undefined && parsedData.meshes !== null) {
                     var loadedSkeletonsIds = [];
                     var loadedMaterialsIds = [];
@@ -68,7 +68,7 @@
                                 // Remove found mesh name from list.
                                 delete meshesNames[meshesNames.indexOf(parsedMesh.name)];
                             }
-        
+
                             //Geometry?
                             if (parsedMesh.geometryId !== undefined && parsedMesh.geometryId !== null) {
                                 //does the file contain geometries?
@@ -118,7 +118,7 @@
                                     }
                                 }
                             }
-        
+
                             // Material ?
                             if (parsedMesh.materialId) {
                                 var materialFound = (loadedMaterialsIds.indexOf(parsedMesh.materialId) !== -1);
@@ -151,7 +151,7 @@
                                     }
                                 }
                             }
-        
+
                             // Skeleton ?
                             if (parsedMesh.skeletonId > -1 && parsedData.skeletons !== undefined && parsedData.skeletons !== null) {
                                 var skeletonAlreadyLoaded = (loadedSkeletonsIds.indexOf(parsedMesh.skeletonId) > -1);
@@ -173,7 +173,7 @@
                             log += "\n\tMesh " + mesh.toString(fullDetails);
                         }
                     }
-        
+
                     // Connecting parents
                     var currentMesh: AbstractMesh;
                     for (index = 0, cache = scene.meshes.length; index < cache; index++) {
@@ -183,7 +183,7 @@
                             currentMesh._waitingParentId = undefined;
                         }
                     }
-        
+
                     // freeze and compute world matrix application
                     for (index = 0, cache = scene.meshes.length; index < cache; index++) {
                         currentMesh = scene.meshes[index];
@@ -195,7 +195,7 @@
                         }
                     }
                 }
-    
+
                 // Particles
                 if (parsedData.particleSystems !== undefined && parsedData.particleSystems !== null) {
                     for (index = 0, cache = parsedData.particleSystems.length; index < cache; index++) {
@@ -209,17 +209,21 @@
                 return true;
 
             } catch (err) {
-                Tools.Log(logOperation("importMesh", parsedData ? parsedData.producer : "Unknown") + log);
-                log = null;
-                throw err;
-
+                let msg = logOperation("importMesh", parsedData ? parsedData.producer : "Unknown") + log;
+                if (onError) {
+                    onError(msg, err);
+                } else {
+                    Tools.Log(msg);
+                    log = null;
+                    throw err;
+                }
             } finally {
                 if (log !== null && SceneLoader.loggingLevel !== SceneLoader.NO_LOGGING) {
                     Tools.Log(logOperation("importMesh", parsedData ? parsedData.producer : "Unknown") + (SceneLoader.loggingLevel !== SceneLoader.MINIMAL_LOGGING ? log : ""));
                 }
             }
         },
-        load: (scene: Scene, data: string, rootUrl: string): boolean => {
+        load: (scene: Scene, data: string, rootUrl: string, onError?: (message: string, exception?: any) => void): boolean => {
             // Entire method running in try block, so ALWAYS logs as far as it got, only actually writes details
             // when SceneLoader.debugLogging = true (default), or exception encountered.
             // Everything stored in var log instead of writing separate lines to support only writing in exception,
@@ -229,7 +233,7 @@
                 var parsedData = JSON.parse(data);
                 log = "";
                 var fullDetails = SceneLoader.loggingLevel === SceneLoader.DETAILED_LOGGING;
-                
+
                 // Scene
                 if (parsedData.useDelayedTextureLoading !== undefined && parsedData.useDelayedTextureLoading !== null) {
                     scene.useDelayedTextureLoading = parsedData.useDelayedTextureLoading && !BABYLON.SceneLoader.ForceFullSceneLoadingForIncremental;
@@ -246,7 +250,7 @@
                 if (parsedData.gravity !== undefined && parsedData.gravity !== null) {
                     scene.gravity = BABYLON.Vector3.FromArray(parsedData.gravity);
                 }
-                
+
                 // Fog
                 if (parsedData.fogMode && parsedData.fogMode !== 0) {
                     scene.fogMode = parsedData.fogMode;
@@ -262,7 +266,7 @@
                         case 3: log += "linear\n"; break;
                     }
                 }
-                
+
                 //Physics
                 if (parsedData.physicsEnabled) {
                     var physicsPlugin;
@@ -276,12 +280,12 @@
                     var physicsGravity = parsedData.physicsGravity ? BABYLON.Vector3.FromArray(parsedData.physicsGravity) : null;
                     scene.enablePhysics(physicsGravity, physicsPlugin);
                 }
-                
+
                 // Metadata
                 if (parsedData.metadata !== undefined && parsedData.metadata !== null) {
                     scene.metadata = parsedData.metadata;
                 }
-                
+
                 //collisions, if defined. otherwise, default is true
                 if (parsedData.collisionsEnabled !== undefined && parsedData.collisionsEnabled !== null) {
                     scene.collisionsEnabled = parsedData.collisionsEnabled;
@@ -299,7 +303,7 @@
                         log += "\n\t\t" + light.toString(fullDetails);
                     }
                 }
-    
+
                 // Animations
                 if (parsedData.animations !== undefined && parsedData.animations !== null) {
                     for (index = 0, cache = parsedData.animations.length; index < cache; index++) {
@@ -314,7 +318,7 @@
                 if (parsedData.autoAnimate) {
                     scene.beginAnimation(scene, parsedData.autoAnimateFrom, parsedData.autoAnimateTo, parsedData.autoAnimateLoop, parsedData.autoAnimateSpeed || 1.0);
                 }
-    
+
                 // Materials
                 if (parsedData.materials !== undefined && parsedData.materials !== null) {
                     for (index = 0, cache = parsedData.materials.length; index < cache; index++) {
@@ -340,7 +344,7 @@
                         var parsedManager = MorphTargetManager.Parse(managerData, scene);
                     }
                 }
-    
+
                 // Skeletons
                 if (parsedData.skeletons !== undefined && parsedData.skeletons !== null) {
                     for (index = 0, cache = parsedData.skeletons.length; index < cache; index++) {
@@ -350,7 +354,7 @@
                         log += "\n\t\t" + skeleton.toString(fullDetails);
                     }
                 }
-    
+
                 // Geometries
                 var geometries = parsedData.geometries;
                 if (geometries !== undefined && geometries !== null) {
@@ -362,7 +366,7 @@
                             Geometry.Primitives.Box.Parse(parsedBox, scene);
                         }
                     }
-    
+
                     // Spheres
                     var spheres = geometries.spheres;
                     if (spheres !== undefined && spheres !== null) {
@@ -371,7 +375,7 @@
                             Geometry.Primitives.Sphere.Parse(parsedSphere, scene);
                         }
                     }
-    
+
                     // Cylinders
                     var cylinders = geometries.cylinders;
                     if (cylinders !== undefined && cylinders !== null) {
@@ -380,7 +384,7 @@
                             Geometry.Primitives.Cylinder.Parse(parsedCylinder, scene);
                         }
                     }
-    
+
                     // Toruses
                     var toruses = geometries.toruses;
                     if (toruses !== undefined && toruses !== null) {
@@ -389,7 +393,7 @@
                             Geometry.Primitives.Torus.Parse(parsedTorus, scene);
                         }
                     }
-    
+
                     // Grounds
                     var grounds = geometries.grounds;
                     if (grounds !== undefined && grounds !== null) {
@@ -398,7 +402,7 @@
                             Geometry.Primitives.Ground.Parse(parsedGround, scene);
                         }
                     }
-    
+
                     // Planes
                     var planes = geometries.planes;
                     if (planes !== undefined && planes !== null) {
@@ -407,7 +411,7 @@
                             Geometry.Primitives.Plane.Parse(parsedPlane, scene);
                         }
                     }
-    
+
                     // TorusKnots
                     var torusKnots = geometries.torusKnots;
                     if (torusKnots !== undefined && torusKnots !== null) {
@@ -416,7 +420,7 @@
                             Geometry.Primitives.TorusKnot.Parse(parsedTorusKnot, scene);
                         }
                     }
-    
+
                     // VertexData
                     var vertexData = geometries.vertexData;
                     if (vertexData !== undefined && vertexData !== null) {
@@ -426,7 +430,7 @@
                         }
                     }
                 }
-    
+
                 // Meshes
                 if (parsedData.meshes !== undefined && parsedData.meshes !== null) {
                     for (index = 0, cache = parsedData.meshes.length; index < cache; index++) {
@@ -436,7 +440,7 @@
                         log += "\n\t\t" + mesh.toString(fullDetails);
                     }
                 }
-    
+
                 // Cameras
                 if (parsedData.cameras !== undefined && parsedData.cameras !== null) {
                     for (index = 0, cache = parsedData.cameras.length; index < cache; index++) {
@@ -449,7 +453,7 @@
                 if (parsedData.activeCameraID !== undefined && parsedData.activeCameraID !== null) {
                     scene.setActiveCameraByID(parsedData.activeCameraID);
                 }
-    
+
                 // Browsing all the graph to connect the dots
                 for (index = 0, cache = scene.cameras.length; index < cache; index++) {
                     var camera = scene.cameras[index];
@@ -466,7 +470,7 @@
                         light._waitingParentId = undefined;
                     }
                 }
-    
+
                 // Sounds
                 var loadedSounds: Sound[] = [];
                 var loadedSound: Sound;
@@ -489,7 +493,7 @@
                 }
 
                 loadedSounds = [];
-    
+
                 // Connect parents & children and parse actions
                 for (index = 0, cache = scene.meshes.length; index < cache; index++) {
                     var mesh = scene.meshes[index];
@@ -502,7 +506,7 @@
                         mesh._waitingActions = undefined;
                     }
                 }
-    
+
                 // freeze world matrix application
                 for (index = 0, cache = scene.meshes.length; index < cache; index++) {
                     var currentMesh = scene.meshes[index];
@@ -513,7 +517,7 @@
                         currentMesh.computeWorldMatrix(true);
                     }
                 }
-    
+
                 // Particles Systems
                 if (parsedData.particleSystems !== undefined && parsedData.particleSystems !== null) {
                     for (index = 0, cache = parsedData.particleSystems.length; index < cache; index++) {
@@ -521,7 +525,7 @@
                         ParticleSystem.Parse(parsedParticleSystem, scene, rootUrl);
                     }
                 }
-    
+
                 // Lens flares
                 if (parsedData.lensFlareSystems !== undefined && parsedData.lensFlareSystems !== null) {
                     for (index = 0, cache = parsedData.lensFlareSystems.length; index < cache; index++) {
@@ -529,7 +533,7 @@
                         LensFlareSystem.Parse(parsedLensFlareSystem, scene, rootUrl);
                     }
                 }
-    
+
                 // Shadows
                 if (parsedData.shadowGenerators !== undefined && parsedData.shadowGenerators !== null) {
                     for (index = 0, cache = parsedData.shadowGenerators.length; index < cache; index++) {
@@ -537,7 +541,7 @@
                         ShadowGenerator.Parse(parsedShadowGenerator, scene);
                     }
                 }
-                
+
                 // Lights exclusions / inclusions
                 for (index = 0, cache = scene.lights.length; index < cache; index++) {
                     var light = scene.lights[index];
@@ -567,20 +571,24 @@
                         light._includedOnlyMeshesIds = [];
                     }
                 }
-    
+
                 // Actions (scene)
                 if (parsedData.actions !== undefined && parsedData.actions !== null) {
                     ActionManager.Parse(parsedData.actions, null, scene);
                 }
-    
+
                 // Finish
                 return true;
 
             } catch (err) {
-                Tools.Log(logOperation("importScene", parsedData ? parsedData.producer : "Unknown") + log);
-                log = null;
-                throw err;
-
+                let msg = logOperation("importScene", parsedData ? parsedData.producer : "Unknown") + log;
+                if (onError) {
+                    onError(msg, err);
+                } else {
+                    Tools.Log(msg);
+                    log = null;
+                    throw err;
+                }
             } finally {
                 if (log !== null && SceneLoader.loggingLevel !== SceneLoader.NO_LOGGING) {
                     Tools.Log(logOperation("importScene", parsedData ? parsedData.producer : "Unknown") + (SceneLoader.loggingLevel !== SceneLoader.MINIMAL_LOGGING ? log : ""));

--- a/src/Loading/babylon.sceneLoader.ts
+++ b/src/Loading/babylon.sceneLoader.ts
@@ -80,7 +80,7 @@
 
         public static set CleanBoneMatrixWeights(value: boolean) {
             SceneLoader._CleanBoneMatrixWeights = value;
-        }        
+        }
 
         // Members
         public static OnPluginActivatedObservable = new Observable<ISceneLoaderPlugin | ISceneLoaderPluginAsync>();
@@ -234,7 +234,7 @@
 
             var errorHandler = (message?: string, exception?: any) => {
                 if (onError) {
-                    onError(scene, "Unable to import meshes from " + rootUrl + sceneFilename + (message ? ": " + message : ""));
+                    onError(scene, "Unable to import meshes from " + rootUrl + sceneFilename + (message ? ": " + message : ""), exception);
                 }
                 scene._removePendingData(loadingToken);
             };
@@ -342,7 +342,7 @@
                         if (onSuccess) {
                             onSuccess(scene);
                         }
-                        
+
                         scene.loadingPluginName = plugin.name;
                         scene._removePendingData(loadingToken);
                     }, progressHandler, errorHandler);

--- a/src/Loading/babylon.sceneLoader.ts
+++ b/src/Loading/babylon.sceneLoader.ts
@@ -8,8 +8,8 @@
     export interface ISceneLoaderPlugin {
         name: string;
         extensions: string | ISceneLoaderPluginExtensions;
-        importMesh: (meshesNames: any, scene: Scene, data: any, rootUrl: string, meshes: AbstractMesh[], particleSystems: ParticleSystem[], skeletons: Skeleton[], onError: (message: string) => void) => boolean;
-        load: (scene: Scene, data: string, rootUrl: string, onError: (message: string) => void) => boolean;
+        importMesh: (meshesNames: any, scene: Scene, data: any, rootUrl: string, meshes: AbstractMesh[], particleSystems: ParticleSystem[], skeletons: Skeleton[], onError?: (message: string, exception?: any) => void) => boolean;
+        load: (scene: Scene, data: string, rootUrl: string, onError?: (message: string, exception?: any) => void) => boolean;
         canDirectLoad?: (data: string) => boolean;
     }
 
@@ -17,7 +17,7 @@
         name: string;
         extensions: string | ISceneLoaderPluginExtensions;
         importMeshAsync: (meshesNames: any, scene: Scene, data: any, rootUrl: string, onSuccess: (meshes: AbstractMesh[], particleSystems: ParticleSystem[], skeletons: Skeleton[]) => void, onProgress: (event: ProgressEvent) => void, onError: (message: string) => void) => void;
-        loadAsync: (scene: Scene, data: string, rootUrl: string, onSuccess: () => void, onProgress: (event: ProgressEvent) => void, onError: (message: string) => void) => void;
+        loadAsync: (scene: Scene, data: string, rootUrl: string, onSuccess: () => void, onProgress: (event: ProgressEvent) => void, onError: (message: string, exception?: any) => void) => void;
         canDirectLoad?: (data: string) => boolean;
     }
 
@@ -311,7 +311,7 @@
 
             var errorHandler = (message?: string, exception?: any) => {
                 if (onError) {
-                    onError(scene, "Unable to load from " + rootUrl + sceneFilename + (message ? ": " + message : ""));
+                    onError(scene, "Unable to load from " + rootUrl + sceneFilename + (message ? ": " + message : ""), exception);
                 }
                 scene._removePendingData(loadingToken);
                 scene.getEngine().hideLoadingUI();


### PR DESCRIPTION
The exception was missing as a (3rd) variable in many of the onError callbacks of the loader.
I also added it to the plugin, so we will have more consistent error handling . Now, when an error occures in the plugin's load function, no exception will be thrown if the onError is defined.